### PR TITLE
Don't EXIT_OK on invalid usage or missing device name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,7 @@ main (int argc, char *argv[])
 		case '?':
 		default:
 			print_help();
-			exit (EXIT_OK);
+			exit (EXIT_ERROR);
 			break;
 		}
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -211,7 +211,7 @@ main (int argc, char *argv[])
 	/* Get device name argument */
 	if (optind >= argc) {
 		print_usage();
-		exit (EXIT_OK);
+		exit (EXIT_ERROR);
 	}
 	device_name = argv[optind];
 


### PR DESCRIPTION
fixes https://github.com/alobbs/macchanger/issues/43 and https://github.com/alobbs/macchanger/issues/42